### PR TITLE
Removing mock_request() and getting the request from the Context instead...

### DIFF
--- a/oembed/parsers/base.py
+++ b/oembed/parsers/base.py
@@ -21,7 +21,7 @@ class BaseParser(object):
         - original_url: the url that was passed to the consumer
         """
         provided_context = context or Context()
-        context = RequestContext(mock_request())
+        context = RequestContext(provided_context["request"])
         context.update(provided_context)
         
         # templates are named for the resources they display, i.e. video.html


### PR DESCRIPTION
..., this way all other request context should be included. Fix for Issue #13
